### PR TITLE
Use 'exec' to start catalina.sh

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -120,7 +120,7 @@ run_jasperserver() {
   config_customization
 
   # Start tomcat.
-  catalina.sh run
+  exec catalina.sh run
 }
 
 init_database() {


### PR DESCRIPTION
Use 'exec' so that entrypoint.sh's bash process is replaced
by catalina.sh, and catalina.sh runs as PID 1.