### PR TITLE
Update Dockerfile-cmdline

### DIFF
--- a/Dockerfile-cmdline
+++ b/Dockerfile-cmdline
@@ -47,8 +47,7 @@ COPY ${EXPLODED_INSTALLER_DIRECTORY}/buildomatic/lib /usr/src/jasperreports-serv
 # js-docker specific scripts and resources
 COPY scripts /usr/src/jasperreports-server/scripts/
 
-RUN echo "nameserver 8.8.8.8" | tee /etc/resolv.conf > /dev/null && \
-    chmod +x /usr/src/jasperreports-server/scripts/*.sh && \
+RUN chmod +x /usr/src/jasperreports-server/scripts/*.sh && \
     /usr/src/jasperreports-server/scripts/installPackagesForJasperserver-pro-cmdline.sh && \
 	echo "finished installing packages" && \
 	cp -R /usr/src/jasperreports-server/scripts/buildomatic /usr/src/jasperreports-server/buildomatic && \


### PR DESCRIPTION
The removed line in this PR...

`echo "nameserver 8.8.8.8" | tee /etc/resolv.conf > /dev/null && \`

causes a problem when executing `docker-compose build`:

```
 > [16/16] RUN echo "nameserver 8.8.8.8" | tee /etc/resolv.conf > /dev/null &&     chmod +x /usr/src/jasperreports-server/scripts/*.sh &&     /usr/src/jasperreports-server/scripts/installPackagesForJasperserver-pro-cmdline.sh && 	echo "finished installing packages" && 	cp -R /usr/src/jasperreports-server/scripts/buildomatic /usr/src/jasperreports-server/buildomatic && 	chmod +x /usr/src/jasperreports-server/buildomatic/js-* && 	chmod +x /usr/src/jasperreports-server/buildomatic/bin/*.sh && 	chmod +x /usr/src/jasperreports-server/apache-ant/bin/* &&     java -version &&     wget "https://jdbc.postgresql.org/download/postgresql-42.2.5.jar"          -P /usr/src/jasperreports-server/buildomatic/conf_source/db/postgresql/jdbc --no-verbose:
#21 0.237 tee: /etc/resolv.conf: Read-only file system
```

When this line is removed, the build proceeds successfully, and the container starts successfully as well.