### PR TITLE
Feature/use v2 not v2beta2 hpa

### DIFF
--- a/jaspersoft-containers/K8s/jrs/helm/templates/hpa.yaml
+++ b/jaspersoft-containers/K8s/jrs/helm/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "jrs.fullname" . }}

--- a/jaspersoft-containers/K8s/scalableQueryEngine/helm/templates/hpa.yaml
+++ b/jaspersoft-containers/K8s/scalableQueryEngine/helm/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.autoscaling.enabled (not .Values.customMetricScaling.enabled)  -}}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "queryEngine.fullname" . }}


### PR DESCRIPTION
[HorizontalPodAutoscaler v2beta2](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#horizontalpodautoscaler-v126) as its been deprecated in k8s 1.23 and removed in 1.26.